### PR TITLE
Using tcp instead of tcphdr to access destination port 443 in network.h is_https_traffic function.

### DIFF
--- a/eBPF/chapter8/network.h
+++ b/eBPF/chapter8/network.h
@@ -29,8 +29,8 @@ static __always_inline unsigned short is_https_traffic(void *data,
     return 0;
 
   //  Checking to see if destination port is 443 and returning it.
-  if (bpf_ntoh(tcphdr->destination) == 443) {
-    return (tcphdr->destination);
+  if (tcp->dest == 443) {
+    return (tcp->dest);
   }
 
 }


### PR DESCRIPTION
Using tcp instead of tcphdr to access destination port 443 in network.h is_https_traffic function.