### PR TITLE
dropping inbound traffic to port 443. note: xdp can only look at egress traffic.

### DIFF
--- a/eBPF/chapter8/network.h
+++ b/eBPF/chapter8/network.h
@@ -3,7 +3,7 @@
 #include <linux/ip.h>
 #include <linux/tcp.h>
 
-static __always_inline unsigned short tcp_src_port(void *data,
+static __always_inline unsigned short tcp_ingress_port(void *data,
                                                            void *data_end) {
   struct ethhdr *eth = data;
   if (data + sizeof(struct ethhdr) > data_end)

--- a/eBPF/chapter8/ping.bpf.c
+++ b/eBPF/chapter8/ping.bpf.c
@@ -12,8 +12,10 @@ int xdp(struct xdp_md *ctx) {
         return XDP_PASS;
   }
 
-  if (tcp_src_port(data, data_end) == 443) {
-    bpf_trace_printk("Port: %u\n", tcp_src_port(data, data_end));
+  //  Dropping ingress traffic to tcp port 443.
+  if (tcp_ingress_port(data, data_end) == 443) {
+    bpf_trace_printk("Dropped traffic to HTTPS port: %u\n", tcp_ingress_port(data, data_end));
+    return XDP_DROP;
   }
 
   return XDP_PASS;


### PR DESCRIPTION
dropping inbound traffic to port 443. note: xdp can only look at egress traffic.